### PR TITLE
Ce 215 log filtering

### DIFF
--- a/gremlinapi/__init__.py
+++ b/gremlinapi/__init__.py
@@ -52,6 +52,10 @@ class SecretsFilter(logging.Filter):
             record.msg = re.sub(rf"\s{GremlinAPIConfig.bearer_token}[\'\s]?",
                                 ' ...'+GremlinAPIConfig.bearer_token[-4:],
                                 record.msg)
+        if len(GremlinAPIConfig.password) >= 1:
+            record.msg = re.sub(rf"\s{GremlinAPIConfig.password}[\'\s]?",
+                                ' [PASSWORD REDACTED]',
+                                record.msg)
         return record
 
 logging_levels = {

--- a/gremlinapi/__init__.py
+++ b/gremlinapi/__init__.py
@@ -44,15 +44,16 @@ __version__ = get_version()
 # Logging Configuration
 class SecretsFilter(logging.Filter):
     def filter(self, record):
-        if len(GremlinAPIConfig.api_key) >= 1:
+        secret_length = 5
+        if len(GremlinAPIConfig.api_key) >= secret_length:
             record.msg = re.sub(rf"\s{GremlinAPIConfig.api_key}[\'\s]?",
                                 ' ...'+GremlinAPIConfig.api_key[-4:],
                                 record.msg)
-        if len(GremlinAPIConfig.bearer_token) >= 1:
+        if len(GremlinAPIConfig.bearer_token) >= secret_length:
             record.msg = re.sub(rf"\s{GremlinAPIConfig.bearer_token}[\'\s]?",
                                 ' ...'+GremlinAPIConfig.bearer_token[-4:],
                                 record.msg)
-        if len(GremlinAPIConfig.password) >= 1:
+        if len(GremlinAPIConfig.password) >= secret_length:
             record.msg = re.sub(rf"\s{GremlinAPIConfig.password}[\'\s]?",
                                 ' [PASSWORD REDACTED]',
                                 record.msg)

--- a/gremlinapi/__init__.py
+++ b/gremlinapi/__init__.py
@@ -42,7 +42,17 @@ __version__ = get_version()
 
 
 # Logging Configuration
-logging.getLogger('GremlinAPI.client').addHandler(logging.StreamHandler())
+class SecretsFilter(logging.Filter):
+    def filter(self, record):
+        if len(GremlinAPIConfig.api_key) >= 1:
+            record.msg = re.sub(rf"\s{GremlinAPIConfig.api_key}[\'\s]?",
+                                ' ...'+GremlinAPIConfig.api_key[-4:],
+                                record.msg)
+        if len(GremlinAPIConfig.bearer_token) >= 1:
+            record.msg = re.sub(rf"\s{GremlinAPIConfig.bearer_token}[\'\s]?",
+                                ' ...'+GremlinAPIConfig.bearer_token[-4:],
+                                record.msg)
+        return record
 
 logging_levels = {
     'CRITICAL': logging.CRITICAL,
@@ -53,6 +63,11 @@ logging_levels = {
 }
 
 log = logging.getLogger('GremlinAPI.client')
+log_handler = logging.StreamHandler()
+log_formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
+log_handler.setFormatter(log_formatter)
+log.addFilter(SecretsFilter())
+log.addHandler(log_handler)
 log.setLevel(logging_levels.get(os.getenv('GREMLIN_PYTHON_API_LOG_LEVEL', 'WARNING'), logging.WARNING))
 
 # API Settings

--- a/gremlinapi/util.py
+++ b/gremlinapi/util.py
@@ -7,7 +7,7 @@ import logging
 
 log = logging.getLogger('GremlinAPI.client')
 
-_version = '0.3.10'
+_version = '0.3.11'
 
 
 def get_version():

--- a/gremlinapi/util.py
+++ b/gremlinapi/util.py
@@ -7,7 +7,7 @@ import logging
 
 log = logging.getLogger('GremlinAPI.client')
 
-_version = '0.3.11'
+_version = '0.3.12'
 
 
 def get_version():


### PR DESCRIPTION
Created a logging filter that, for most cases, will filter out api keys, bearer tokens and passwords from logs. In the case of key/bearer, we'll expose the last 4 characters of the string, which can be useful for troubleshooting.