### PR TITLE
Update for companies and users endpoint changes

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.1
+current_version = 0.6.2
 commit = True
 tag = True
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.2
+current_version = 0.6.3
 commit = True
 tag = True
 

--- a/examples/companies.md
+++ b/examples/companies.md
@@ -32,7 +32,7 @@ response = companies.invite_company_user(identifier=company_id, body=user_email_
 from gremlinapi.companies import GremlinAPICompanies as companies
 
 company_id = 'COMPANY_GUID'
-user_email_body = { 'emails': ['andjohn+1@gremlin.com', 'andjohn+2@gremlin.com'] }
+user_email_body = [{ 'emails': 'andjohn+1@gremlin.com'}, { 'email': 'andjohn+2@gremlin.com'}]
 response = companies.invite_company_user(identifier=company_id, body=user_email_body)
 ```
 

--- a/gremlinapi/companies.py
+++ b/gremlinapi/companies.py
@@ -48,11 +48,11 @@ class GremlinAPICompanies(GremlinAPI):
         method = 'POST'
         identifier = cls._error_if_not_param('identifier', **kwargs)
         data = cls._error_if_not_json_body(**kwargs)
-        body = []
-        if not isinstance(data, list):
-            body = [data]
+        if isinstance(data, dict):
+            data = [dict(data)]
+        print(data)
         endpoint = f'/companies/{identifier}/invites'
-        payload = cls._payload(**{'headers': https_client.header(), 'body': body})
+        payload = cls._payload(**{'headers': https_client.header(), 'body': data})
         (resp, body) = https_client.api_call(method, endpoint, **payload)
         return body
 

--- a/gremlinapi/companies.py
+++ b/gremlinapi/companies.py
@@ -50,7 +50,6 @@ class GremlinAPICompanies(GremlinAPI):
         data = cls._error_if_not_json_body(**kwargs)
         if isinstance(data, dict):
             data = [dict(data)]
-        print(data)
         endpoint = f'/companies/{identifier}/invites'
         payload = cls._payload(**{'headers': https_client.header(), 'body': data})
         (resp, body) = https_client.api_call(method, endpoint, **payload)

--- a/gremlinapi/companies.py
+++ b/gremlinapi/companies.py
@@ -48,6 +48,8 @@ class GremlinAPICompanies(GremlinAPI):
         method = 'POST'
         identifier = cls._error_if_not_param('identifier', **kwargs)
         data = cls._error_if_not_json_body(**kwargs)
+        if not isinstance(data, list):
+            data = list(data)
         endpoint = f'/companies/{identifier}/invites'
         payload = cls._payload(**{'headers': https_client.header(), 'body': data})
         (resp, body) = https_client.api_call(method, endpoint, **payload)

--- a/gremlinapi/companies.py
+++ b/gremlinapi/companies.py
@@ -48,10 +48,11 @@ class GremlinAPICompanies(GremlinAPI):
         method = 'POST'
         identifier = cls._error_if_not_param('identifier', **kwargs)
         data = cls._error_if_not_json_body(**kwargs)
+        body = []
         if not isinstance(data, list):
-            data = list(data)
+            body = [data]
         endpoint = f'/companies/{identifier}/invites'
-        payload = cls._payload(**{'headers': https_client.header(), 'body': data})
+        payload = cls._payload(**{'headers': https_client.header(), 'body': body})
         (resp, body) = https_client.api_call(method, endpoint, **payload)
         return body
 

--- a/gremlinapi/users.py
+++ b/gremlinapi/users.py
@@ -47,11 +47,10 @@ class GremlinAPIUsers(GremlinAPI):
     def add_user_to_team(cls, https_client=get_gremlin_httpclient(), *args, **kwargs):
         method = 'POST'
         data = cls._error_if_not_json_body(**kwargs)
-        body = []
-        if not isinstance(data, list):
-            body = [data]
+        if isinstance(data, dict):
+            data = [dict(data)]
         endpoint = cls._optional_team_endpoint(f'/users', **kwargs)
-        payload = cls._payload(**{'headers': https_client.header(), 'body': body})
+        payload = cls._payload(**{'headers': https_client.header(), 'body': data})
         (resp, body) = https_client.api_call(method, endpoint, **payload)
         return body
 

--- a/gremlinapi/users.py
+++ b/gremlinapi/users.py
@@ -47,10 +47,11 @@ class GremlinAPIUsers(GremlinAPI):
     def add_user_to_team(cls, https_client=get_gremlin_httpclient(), *args, **kwargs):
         method = 'POST'
         data = cls._error_if_not_json_body(**kwargs)
+        body = []
         if not isinstance(data, list):
-            data = list(data)
+            body = [data]
         endpoint = cls._optional_team_endpoint(f'/users', **kwargs)
-        payload = cls._payload(**{'headers': https_client.header(), 'body': data})
+        payload = cls._payload(**{'headers': https_client.header(), 'body': body})
         (resp, body) = https_client.api_call(method, endpoint, **payload)
         return body
 

--- a/gremlinapi/users.py
+++ b/gremlinapi/users.py
@@ -47,6 +47,8 @@ class GremlinAPIUsers(GremlinAPI):
     def add_user_to_team(cls, https_client=get_gremlin_httpclient(), *args, **kwargs):
         method = 'POST'
         data = cls._error_if_not_json_body(**kwargs)
+        if not isinstance(data, list):
+            data = list(data)
         endpoint = cls._optional_team_endpoint(f'/users', **kwargs)
         payload = cls._payload(**{'headers': https_client.header(), 'body': data})
         (resp, body) = https_client.api_call(method, endpoint, **payload)

--- a/gremlinapi/util.py
+++ b/gremlinapi/util.py
@@ -7,7 +7,7 @@ import logging
 
 log = logging.getLogger('GremlinAPI.client')
 
-_version = '0.6.2'
+_version = '0.6.3'
 
 
 def get_version():

--- a/gremlinapi/util.py
+++ b/gremlinapi/util.py
@@ -7,7 +7,7 @@ import logging
 
 log = logging.getLogger('GremlinAPI.client')
 
-_version = '0.6.1'
+_version = '0.6.2'
 
 
 def get_version():


### PR DESCRIPTION
Previously the `/companies/{identifier}/invites` and `/users` endpoints would accept either a singular JSON object or a list of them. We're making a change on the backend which will now have these endpoints **only** accept a list of JSON objects. So updating these functions here to check if the request data is a `list` and if not, envelope the data in a list before sending it out.