### PR TITLE
Fix Bug in setting multiple instances of same label with different values

### DIFF
--- a/gremlinapi/attack_helpers.py
+++ b/gremlinapi/attack_helpers.py
@@ -411,9 +411,8 @@ class GremlinTargetContainers(GremlinAttackTargetHelper):
                             self._multiSelectLabels[_label].append(_labels[_label])
                         else:
                             self._multiSelectLabels[_label] = [_labels[_label]]
-                elif isinstance(_labels[_label], list()):
-                    if not isinstance(self._multiSelectLabels[_label]):
-                        self._multiSelectLabels[_label] = list()
+                elif isinstance(_labels[_label], list):
+                    self._multiSelectLabels[_label] = list()
                     for _value in _labels[_label]:
                         if self._valid_label_pair(_label, _value):
                             self._multiSelectLabels[_label].append(_value)


### PR DESCRIPTION
At Workiva we have labels like this on all of our containers in the k8s cluster:
`'app':'<service_name>'`

I was trying to add multiple services to an attack inside a scenario with this line and I was getting the below error
```
GremlinTargetContainers(strategy_type='Random', labels={'app': ['service1', 'service2']}, percent=100)
```

```
Traceback (most recent call last):
  File "script.py", line 55, in <module>
    main(service_config_filename=args.configPath)
  File "script.py", line 32, in main
    target=GremlinTargetContainers(strategy_type='Random', labels={'app': ['service1', 'service2']}, percent=100)
  File ".../lib/python3.8/site-packages/gremlinapi/attack_helpers.py", line 352, in __init__
    self.labels = kwargs.get('labels', dict())
  File ".../lib/python3.8/site-packages/gremlinapi/attack_helpers.py", line 414, in labels
    elif isinstance(_labels[_label], list()):
TypeError: isinstance() arg 2 must be a type or tuple of types
```

It looks like a check on the list type was typo'd maybe and an empty list needs to be created before we start appending the label values. It seemed to work for me! Let me know what you think!