### PR TITLE
Fix bug in target selection

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.16.10
+current_version = 0.16.11
 commit = True
 tag = True
 

--- a/gremlinapi/clients.py
+++ b/gremlinapi/clients.py
@@ -81,7 +81,7 @@ class GremlinAPIClients(GremlinAPI):
 
     @classmethod
     def get_update_client_target_cache(cls) -> [dict]:
-        if not GremlinAPIConfig.client_cache:
+        if (not GremlinAPIConfig.client_cache) or (type(GremlinAPIConfig.client_cache) == type(property())):
             GremlinAPIConfig.client_cache = GremlinAPIClients.list_clients()
         # Collects all containers
         total_containers = []

--- a/gremlinapi/util.py
+++ b/gremlinapi/util.py
@@ -7,7 +7,7 @@ import functools, warnings, inspect
 
 log = logging.getLogger("GremlinAPI.client")
 
-_version = "0.16.10"
+_version = "0.16.11"
 
 
 def get_version():


### PR DESCRIPTION
A bug I realized existed that would manifest if the user had previous ran the sdk and upon re-run did not explicitly clear the cache. Setting, in the config setup, the value of GremlinAPIConfig.client_cache to None or {} causes this bug to not appear. However, if it is not set then the affected code block refreshing the cache doesn't occur.  The check to see if the object doesn't resolve (that is, it's a property object and nothing else) solves the issue.