### PR TITLE
Fix content-type for update_scenario_result_notes endpoint.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.16.12
+current_version = 0.16.13
 commit = True
 tag = True
 

--- a/gremlinapi/scenarios.py
+++ b/gremlinapi/scenarios.py
@@ -267,6 +267,8 @@ class GremlinAPIScenarios(GremlinAPI):
             f"/scenarios/{guid}/runs/{run_number}/resultNotes", **kwargs
         )
         payload: dict = cls._payload(**{"headers": https_client.header(), "body": data})
+        # Content-Type must be text/plain for this endpoint
+        payload['headers']['Content-Type'] = 'text/plain'
         (resp, body) = https_client.api_call(method, endpoint, **payload)
         return body
 

--- a/gremlinapi/util.py
+++ b/gremlinapi/util.py
@@ -7,7 +7,7 @@ import functools, warnings, inspect
 
 log = logging.getLogger("GremlinAPI.client")
 
-_version = "0.16.12"
+_version = "0.16.13"
 
 
 def get_version():


### PR DESCRIPTION
This endpoint requires a text/plain body unlike every other endpoint which wants json.

Simple change.