### PR TITLE
fix: Hostnames list parsing function

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.16.14
+current_version = 0.16.15
 commit = True
 tag = True
 

--- a/gremlinapi/attack_helpers.py
+++ b/gremlinapi/attack_helpers.py
@@ -898,7 +898,7 @@ class GremlinNetworkAttackHelper(GremlinAttackCommandHelper):
                     error_msg = f"valid hostnames required"
                     log.error(error_msg)
                     raise GremlinParameterError(error_msg)
-                self._hostnames = _hostname
+            self._hostnames = _hostnames
         else:
             error_msg = f"hostnames requires a {type(str)} or {type(list)}"
             log.error(error_msg)

--- a/gremlinapi/util.py
+++ b/gremlinapi/util.py
@@ -7,7 +7,7 @@ import functools, warnings, inspect
 
 log = logging.getLogger("GremlinAPI.client")
 
-_version = "0.16.14"
+_version = "0.16.15"
 
 
 def get_version():

--- a/tests/test_attack_helpers.py
+++ b/tests/test_attack_helpers.py
@@ -525,7 +525,7 @@ class TestAttackHelpers(unittest.TestCase):
         self.assertEqual(helper_output, expected_output)
 
     def test_black_hole_attack_repr_str(self) -> None:
-        expected_output = 'GremlinBlackholeAttack({"length": 65, "device": "", "ips": [], "protocol": "", "providers": [], "tags": [], "egress_ports": ["^533"], "hostnames": "^api2.gremlin.com", "ingress_ports": []})'
+        expected_output = 'GremlinBlackholeAttack({"length": 65, "device": "", "ips": [], "protocol": "", "providers": [], "tags": [], "egress_ports": ["^533"], "hostnames": "^api2.gremlin.com,example.com", "ingress_ports": []})'
         kwargs = {
             "length": 65,
             "device": "",
@@ -534,7 +534,7 @@ class TestAttackHelpers(unittest.TestCase):
             "providers": [],
             "tags": [],
             "egress_ports": ["^533"],
-            "hostnames": ["^api2.gremlin.com"],
+            "hostnames": ["^api2.gremlin.com", 'example.com'],
             "ingress_ports": [],
         }
         helper = GremlinBlackholeAttack(**kwargs)


### PR DESCRIPTION
This PR fixes an inconsistency we identified in the SDK (probably a bug).

Currently, passing a list of hostnames to the SDK is not correctly supported. In this example, we assume that it is possible to pass a list to the `hostnames` arg, consistent with what can be done with the `ips` and `egress_ports` args.

Code
```python
        black_hole_attack = GremlinScenarioILFINode(
            command=GremlinBlackholeAttack(
                length=300,
                hostnames=['1.1.1.1', '2.2.2.2'],
                ips=['3.3.3.3', '4.4.4.4'],
                egress_ports=['54', '4405'],
            ),
            target=GremlinKubernetesAttackTargetHelper(
                percentage=100,
                targets=k8s_objects
            )
        )

        scenario.add_node(black_hole_attack)

        pprint.pprint(scenario.api_model())
```
Api model result : 
```json
        "impact_definition": {
          "infra_command_args": {
            "cli_args": [
              "blackhole",
              "-l",
              "300",
              "-i",
              "3.3.3.3,4.4.4.4",
              "-p",
              "54,4405",
              "-h",
              "2,.,2,.,2,.,2"
            ],
            "type": "blackhole"
          },
          "infra_command_type": "blackhole"
        },
```

As we can see, the parsing of the `hostnames` arg is not correct. That is because we're only using the last element of the list to the hostnames in the parsing function, returning a string, not a list. This in turn makes python split the string later (`for hostname in hostnames` on a string)

Here's the api model for this same snippet, with my proposed change : 
```json
        "impact_definition": {
          "infra_command_args": {
            "cli_args": [
              "blackhole",
              "-l",
              "300",
              "-i",
              "3.3.3.3,4.4.4.4",
              "-p",
              "54,4405",
              "-h",
              "1.1.1.1,2.2.2.2"
            ],
            "type": "blackhole"
          },
          "infra_command_type": "blackhole"
        },
```
Now the list is correctly represented in the API model. I have reused the same logic used for the ips.setter method ( (l. 863-869 attack_helpers.py), which I think is the correct one.

This change does *not* break the current SDK API, rather enforces it. It is still possible to use a `Union[str, list]` for this arg.