### PR TITLE
Fixing mismatched pypi versioning

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.16.13
+current_version = 0.16.14
 commit = True
 tag = True
 

--- a/gremlinapi/util.py
+++ b/gremlinapi/util.py
@@ -7,7 +7,7 @@ import functools, warnings, inspect
 
 log = logging.getLogger("GremlinAPI.client")
 
-_version = "0.16.13"
+_version = "0.16.14"
 
 
 def get_version():


### PR DESCRIPTION
Pypi version didn't get properly incremented because of race condition. Simply updating it here to get a new release out.