### PR TITLE
feat(scenarios_runs): add get method to list all scenarios runs

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.16.15
+current_version = 0.16.16
 commit = True
 tag = True
 

--- a/gremlinapi/scenarios.py
+++ b/gremlinapi/scenarios.py
@@ -170,6 +170,41 @@ class GremlinAPIScenarios(GremlinAPI):
 
     @classmethod
     @register_cli_action(
+        "list_scenarios_runs",
+        (),
+        (
+            "startDate",
+            "endDate",
+            "teamId",
+        ),
+    )
+    def list_scenarios_runs(
+        cls,
+        https_client: Type[GremlinAPIHttpClient] = get_gremlin_httpclient(),
+        *args: tuple,
+        **kwargs: dict,
+    ) -> dict:
+        method: str = "GET"
+        timeset: str = ""
+        state_query: str = ""
+        state: str = cls._info_if_not_param("state", **kwargs)
+        start: str = cls._info_if_not_param("startDate", **kwargs)
+        end: str = cls._info_if_not_param("endDate", **kwargs)
+        if start:
+            timeset += f"startDate={start}&"
+        if end:
+            timeset += f"endDate={end}"
+        if state:
+            state_query += f"&state={state}"
+        endpoint: str = cls._optional_team_endpoint(
+            f"/scenarios/runs/?{timeset}{state_query}", **kwargs
+        )
+        payload: dict = cls._payload(**{"headers": https_client.header()})
+        (resp, body) = https_client.api_call(method, endpoint, **payload)
+        return body
+
+    @classmethod
+    @register_cli_action(
         "run_scenario",
         ("guid",),
         (

--- a/gremlinapi/util.py
+++ b/gremlinapi/util.py
@@ -7,7 +7,7 @@ import functools, warnings, inspect
 
 log = logging.getLogger("GremlinAPI.client")
 
-_version = "0.16.15"
+_version = "0.16.16"
 
 
 def get_version():

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -71,6 +71,15 @@ class TestScenarios(unittest.TestCase):
             GremlinAPIScenarios.list_scenario_runs(**mock_scenario_guid), mock_data
         )
 
+    @patch("requests.get")
+    def test_list_scenarios_runs_with_decorator(self, mock_get) -> None:
+        mock_get.return_value = requests.Response()
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json = mock_json
+        self.assertEqual(
+            GremlinAPIScenarios.list_scenarios_runs(**mock_scenario_guid), mock_data
+        )
+
     @patch("requests.post")
     def test_run_scenario_with_decorator(self, mock_get) -> None:
         mock_get.return_value = requests.Response()


### PR DESCRIPTION
Add `[GET] /scenarios/runs` endpoint to gremlin-python capabilities.

This can help check for running scenarios thanks to the `state` parameter.
