### PR TITLE
Fix if logic to allow kwargs team_id

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.16.17
+current_version = 0.16.18
 commit = True
 tag = True
 

--- a/.github/workflows/pypi-test.yaml
+++ b/.github/workflows/pypi-test.yaml
@@ -32,8 +32,8 @@ jobs:
         run: |
           python -m tox -e build-dists --parallel 0
       - name: Publish 📦 to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@master
         with:
-          user: __token__
+          username: __token__
           password: ${{ secrets.Test_PyPI_token }}
           repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/pypi-test.yaml
+++ b/.github/workflows/pypi-test.yaml
@@ -34,6 +34,6 @@ jobs:
       - name: Publish 📦 to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          username: __token__
+          user: __token__
           password: ${{ secrets.Test_PyPI_token }}
           repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/pypi-test.yaml
+++ b/.github/workflows/pypi-test.yaml
@@ -32,7 +32,7 @@ jobs:
         run: |
           python -m tox -e build-dists --parallel 0
       - name: Publish 📦 to Test PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           username: __token__
           password: ${{ secrets.Test_PyPI_token }}

--- a/gremlinapi/gremlinapi.py
+++ b/gremlinapi/gremlinapi.py
@@ -123,12 +123,13 @@ class GremlinAPI(object):
             team_id: str = cls._info_if_not_param("teamId", **kwargs)
         else:
             team_id = cls._info_if_not_param("team_id", **kwargs)
-        if not team_id and type(config.team_id) is str:
-            team_id = config.team_id  # type: ignore
-        else:
-            error_msg: str = f"Endpoint requires a team_id or teamId, none supplied"
-            log.error(error_msg)
-            raise GremlinParameterError(error_msg)
+        if not team_id:
+            if type(config.team_id) is str:
+                team_id = config.team_id  # type: ignore
+            else:
+                error_msg: str = f"Endpoint requires a team_id or teamId, none supplied"
+                log.error(error_msg)
+                raise GremlinParameterError(error_msg)
         endpoint = cls._add_query_param(endpoint, "teamId", team_id)
         return endpoint
 

--- a/gremlinapi/gremlinapi.py
+++ b/gremlinapi/gremlinapi.py
@@ -121,15 +121,14 @@ class GremlinAPI(object):
     def _required_team_endpoint(cls, endpoint: str, **kwargs: dict) -> str:
         if "teamId" in kwargs:
             team_id: str = cls._info_if_not_param("teamId", **kwargs)
+        elif 'team_id' in kwargs:
+            team_id: str = cls._info_if_not_param("team_id", **kwargs)
+        elif type(config.team_id) is str:
+            team_id: str = config.team_id  # type: ignore
         else:
-            team_id = cls._info_if_not_param("team_id", **kwargs)
-        if not team_id:
-            if type(config.team_id) is str:
-                team_id = config.team_id  # type: ignore
-            else:
-                error_msg: str = f"Endpoint requires a team_id or teamId, none supplied"
-                log.error(error_msg)
-                raise GremlinParameterError(error_msg)
+            error_msg: str = f"Endpoint requires a team_id or teamId, none supplied"
+            log.error(error_msg)
+            raise GremlinParameterError(error_msg)
         endpoint = cls._add_query_param(endpoint, "teamId", team_id)
         return endpoint
 

--- a/gremlinapi/util.py
+++ b/gremlinapi/util.py
@@ -7,7 +7,7 @@ import functools, warnings, inspect
 
 log = logging.getLogger("GremlinAPI.client")
 
-_version = "0.16.17"
+_version = "0.16.18"
 
 
 def get_version():

--- a/tox.ini
+++ b/tox.ini
@@ -22,3 +22,5 @@ commands =
     {envpython} setup.py sdist bdist_wheel
 whitelist_externals =
     rm
+allowlist_externals =
+    rm


### PR DESCRIPTION
This logic block was incorrect. We should only be checking the global config object if teamId/team_id not set in the kwargs.

Old logic made it impossible to pass team_id via kwargs.