### PR TITLE
Release 0.20.0

### DIFF
--- a/.github/workflows/pypi-prod.yaml
+++ b/.github/workflows/pypi-prod.yaml
@@ -35,7 +35,7 @@ jobs:
         run: |
           python -m tox -e build-dists --parallel 0
       - name: Publish 📦 to Prod PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           username: __token__
           password: ${{ secrets.Prod_PyPI_token }}

--- a/.github/workflows/pypi-test.yaml
+++ b/.github/workflows/pypi-test.yaml
@@ -35,7 +35,7 @@ jobs:
         run: |
           python -m tox -e build-dists --parallel 0
       - name: Publish 📦 to Test PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           username: __token__
           password: ${{ secrets.Test_PyPI_token }}

--- a/gremlinapi/gremlinapi.py
+++ b/gremlinapi/gremlinapi.py
@@ -142,6 +142,17 @@ class GremlinAPI(object):
         return body
 
     @classmethod
+    def _error_if_not_team_ids(cls, **kwargs: dict) -> list:
+        team_ids: Union[list, str] = cls._info_if_not_param("team_ids", **kwargs)
+        if not team_ids:
+            error_msg: str = f"team_ids not passed to users endpoint: {kwargs}"
+            log.error(error_msg)
+            raise GremlinParameterError(error_msg)
+        if isinstance(team_ids, str):
+            team_ids = [team_ids]
+        return team_ids
+
+    @classmethod
     def _error_if_not_email(cls, **kwargs: dict) -> str:
         email: str = cls._info_if_not_param("email", **kwargs)
         if not email:

--- a/gremlinapi/users.py
+++ b/gremlinapi/users.py
@@ -115,6 +115,24 @@ class GremlinAPIUsers(GremlinAPI):
         return body
 
     @classmethod
+    @register_cli_action("remove_user_from_team", ("email", "body"), ("",))
+    def remove_user_from_team(
+        cls,
+        https_client: Type[GremlinAPIHttpClient] = get_gremlin_httpclient(),
+        *args: tuple,
+        **kwargs: dict,
+    ) -> dict:
+        method: str = "POST"
+        email: str = cls._error_if_not_email(**kwargs)
+        team_ids: Union[list, dict] = cls._error_if_not_json_body(**kwargs)
+        if isinstance(team_ids, str):
+            team_ids = [team_ids]
+        endpoint: str = f"/users/{email}/teams/remove"
+        payload: dict = cls._payload(**{"headers": https_client.header(), "data": {"teamIds": team_ids}})  # type: ignore
+        (resp, body) = https_client.api_call(method, endpoint, **payload)
+        return body
+
+    @classmethod
     @register_cli_action("list_active_user", ("",), ("teamId", "pageSize"))
     def list_active_users(
         cls,

--- a/gremlinapi/users.py
+++ b/gremlinapi/users.py
@@ -115,7 +115,7 @@ class GremlinAPIUsers(GremlinAPI):
         return body
 
     @classmethod
-    @register_cli_action("remove_user_from_team", ("email", "body"), ("",))
+    @register_cli_action("remove_user_from_team", ("email", "team_ids"), ("",))
     def remove_user_from_team(
         cls,
         https_client: Type[GremlinAPIHttpClient] = get_gremlin_httpclient(),
@@ -124,9 +124,7 @@ class GremlinAPIUsers(GremlinAPI):
     ) -> dict:
         method: str = "POST"
         email: str = cls._error_if_not_email(**kwargs)
-        team_ids: Union[list, str] = cls._error_if_not_json_body(**kwargs)
-        if isinstance(team_ids, str):
-            team_ids = [team_ids]
+        team_ids: Union[list, str] = cls._error_if_not_team_ids(**kwargs)
         endpoint: str = f"/users/{email}/teams/remove"
         payload: dict = cls._payload(**{"headers": https_client.header(), "data": {"teamIds": team_ids}})  # type: ignore
         (resp, body) = https_client.api_call(method, endpoint, **payload)

--- a/gremlinapi/users.py
+++ b/gremlinapi/users.py
@@ -124,7 +124,7 @@ class GremlinAPIUsers(GremlinAPI):
     ) -> dict:
         method: str = "POST"
         email: str = cls._error_if_not_email(**kwargs)
-        team_ids: Union[list, dict] = cls._error_if_not_json_body(**kwargs)
+        team_ids: Union[list, str] = cls._error_if_not_json_body(**kwargs)
         if isinstance(team_ids, str):
             team_ids = [team_ids]
         endpoint: str = f"/users/{email}/teams/remove"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gremlinapi"
-version = "0.19.3"
+version = "0.20.0"
 description = "Gremlin library for Python"
 readme = "README.md"
 license = { text = "Apache 2.0" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gremlinapi"
-version = "0.20.0"
+version = "0.20.1"
 description = "Gremlin library for Python"
 readme = "README.md"
 license = { text = "Apache 2.0" }

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -8,7 +8,7 @@ from gremlinapi.users import (
     GremlinAPIUsersAuthMFA,
 )
 
-from .util import mock_json, mock_data, mock_users, mock_body, mock_paged_json, mock_paged_data
+from .util import mock_json, mock_data, mock_users, mock_body, mock_team_ids, mock_paged_json, mock_paged_data
 
 
 class TestUsers(unittest.TestCase):
@@ -47,12 +47,12 @@ class TestUsers(unittest.TestCase):
         self.assertEqual(GremlinAPIUsers.deactivate_user(**mock_users), mock_data)
 
     @patch("requests.post")
-    def test_remove_user_from_team_with_decorator(self, mock_post) -> None:
-        mock_post.return_value = requests.Response()
-        mock_post.return_value.status_code = 200
-        mock_post.return_value.json = mock_json
+    def test_remove_user_from_team_with_decorator(self, mock_get) -> None:
+        mock_get.return_value = requests.Response()
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json = mock_json
         self.assertEqual(
-            GremlinAPIUsers.remove_user_from_team(**{**mock_users, **mock_body}), mock_data
+            GremlinAPIUsers.remove_user_from_team(**{**mock_users, **mock_team_ids}), mock_data
         )
 
     @patch("requests.get")

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -46,6 +46,15 @@ class TestUsers(unittest.TestCase):
         mock_get.return_value.json = mock_json
         self.assertEqual(GremlinAPIUsers.deactivate_user(**mock_users), mock_data)
 
+    @patch("requests.post")
+    def test_remove_user_from_team_with_decorator(self, mock_post) -> None:
+        mock_post.return_value = requests.Response()
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json = mock_json
+        self.assertEqual(
+            GremlinAPIUsers.remove_user_from_team(**{**mock_users, **mock_body}), mock_data
+        )
+
     @patch("requests.get")
     def test_list_active_users_with_decorator(self, mock_get) -> None:
         mock_get.return_value = requests.Response()

--- a/tests/util.py
+++ b/tests/util.py
@@ -43,6 +43,7 @@ mock_base_url = "https://api.gremlin.com/v1"
 
 mock_org_id = "1234567890a"
 mock_team_id = "1234567890a"
+mock_team_ids = {"team_ids": [mock_team_id]}
 mock_body = {"body": mock_data}
 mock_guid = {"guid": mock_data}
 mock_scenario_guid = {


### PR DESCRIPTION
Add remove_user_from_team endpoint (POST /users/{email}/teams/remove).
--
Allows removing a user from multiple teams with a single method for cleaner API interactions.